### PR TITLE
CHORE: 레이아웃 컴포넌트 생성

### DIFF
--- a/src/components/dashboardHeader/style.ts
+++ b/src/components/dashboardHeader/style.ts
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
-const Container = styled.div`
+const Container = styled.header`
+  position: absolute;
+  top: 0;
+  left: 0;
   padding-left: 300px;
   width: 100%;
   height: 70px;

--- a/src/components/side-menu/style.ts
+++ b/src/components/side-menu/style.ts
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 const Container = styled.div`
   width: 300px;
   height: 100%;
-  position: fixed;
   border-right: 1px solid ${({ theme }) => theme.color.gray_d9};
   overflow-x: hidden;
   overflow-y: scroll;
   background-color: ${({ theme }) => theme.color.white};
+  z-index: 10;
 
   &::-webkit-scrollbar {
     width: 5px;

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,13 +1,6 @@
-import DashboardHeader from '@/components/dashboardHeader';
-import SideMenu from '@/components/side-menu';
-
 const DashBoard = () => {
-  return (
-    <>
-      <SideMenu />
-      <DashboardHeader />
-    </>
-  );
+  // 로그인 후에는 동일한 헤더와 네브를 봐야하니 layout 파일로 옮김.
+  return <></>;
 };
 
 export default DashBoard;

--- a/src/routes/layout/index.tsx
+++ b/src/routes/layout/index.tsx
@@ -1,15 +1,19 @@
 import DashboardHeader from '@/components/dashboardHeader';
 import SideMenu from '@/components/side-menu';
 import { Outlet } from 'react-router-dom';
+import StWrapper from './style';
 
 const Layout = () => {
   return (
     <>
       <DashboardHeader />
       <main>
-        <SideMenu />
-        <Outlet />
-        <h1>layout</h1>
+        <StWrapper>
+          <SideMenu />
+          <div id='container'>
+            <Outlet />
+          </div>
+        </StWrapper>
       </main>
     </>
   );

--- a/src/routes/layout/index.tsx
+++ b/src/routes/layout/index.tsx
@@ -1,0 +1,18 @@
+import DashboardHeader from '@/components/dashboardHeader';
+import SideMenu from '@/components/side-menu';
+import { Outlet } from 'react-router-dom';
+
+const Layout = () => {
+  return (
+    <>
+      <DashboardHeader />
+      <main>
+        <SideMenu />
+        <Outlet />
+        <h1>layout</h1>
+      </main>
+    </>
+  );
+};
+
+export default Layout;

--- a/src/routes/layout/style.ts
+++ b/src/routes/layout/style.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+const StWrapper = styled.div`
+  display: flex;
+  height: 100vh;
+
+  #container {
+    padding-top: 70px;
+  }
+`;
+
+export default StWrapper;

--- a/src/routes/protected-routes/index.tsx
+++ b/src/routes/protected-routes/index.tsx
@@ -1,0 +1,29 @@
+import Cookies from 'js-cookie';
+import { ReactElement } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+interface PrivateRouteProps {
+  children?: ReactElement;
+  authentication: boolean;
+}
+
+/**
+ *
+ * @param 로그인 인증 필요 여부를 받아와야함 (로그인 필요 = true / 로그인 필요 x = false)
+ * @returns
+ */
+const PrivateRoutes = ({ authentication }: PrivateRouteProps): React.ReactElement | null => {
+  // 로그인 했을 경우 true
+  // 로그인 하지않았을 경우 false
+  const isAuthenticated = !!Cookies.get('accessToken');
+
+  if (authentication) {
+    // 로그인 상태일 때 접근 가능
+    return isAuthenticated === null || isAuthenticated === false ? <Navigate to='/sign-in' /> : <Outlet />;
+  } else {
+    // 로그인 상태가 아닐때만 접근 가능
+    return isAuthenticated === null || isAuthenticated === false ? <Outlet /> : <Navigate to='/dashboard' />;
+  }
+};
+
+export default PrivateRoutes;

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,6 +1,7 @@
 import { lazy } from 'react';
 import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router-dom';
 import Loading from './loading';
+import Layout from './layout';
 
 /*
 사용자가 처음 웹페이지에 진입하면, 번들링된 js파일을 다운받게 되는데,
@@ -29,8 +30,10 @@ const PrimaryRoute = (
       <Route path='sign-up' element={<SignUpPage />} />
     </Route>
     <Route element={<ProtectedRoutes authentication={true} />}>
-      <Route path='dashboard' element={<DashBoardPage />} />
-      <Route path='dashboard-test' element={<DashBoardTestPage />} />
+      <Route path='/' element={<Layout />}>
+        <Route path='dashboard' element={<DashBoardPage />} />
+        <Route path='dashboard-test' element={<DashBoardTestPage />} />
+      </Route>
     </Route>
     <Route path='*' element={<NotFoundPage />} />
   </Route>

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -18,15 +18,20 @@ const SignInPage = lazy(() => import('@pages/sign-in'));
 const SignUpPage = lazy(() => import('@pages/sign-up'));
 const DashBoardPage = lazy(() => import('@pages/dashboard'));
 const DashBoardTestPage = lazy(() => import('@pages/dashboard-test'));
+const ProtectedRoutes = lazy(() => import('@routes/protected-routes'));
 const NotFoundPage = lazy(() => import('@pages/not-found'));
 
 const PrimaryRoute = (
   <Route path='/' element={<Loading />}>
-    <Route index element={<LandingPage />} />
-    <Route path='sign-in' element={<SignInPage />} />
-    <Route path='sign-up' element={<SignUpPage />} />
-    <Route path='dashboard' element={<DashBoardPage />} />
-    <Route path='dashboard-test' element={<DashBoardTestPage />} />
+    <Route element={<ProtectedRoutes authentication={false} />}>
+      <Route index element={<LandingPage />} />
+      <Route path='sign-in' element={<SignInPage />} />
+      <Route path='sign-up' element={<SignUpPage />} />
+    </Route>
+    <Route element={<ProtectedRoutes authentication={true} />}>
+      <Route path='dashboard' element={<DashBoardPage />} />
+      <Route path='dashboard-test' element={<DashBoardTestPage />} />
+    </Route>
     <Route path='*' element={<NotFoundPage />} />
   </Route>
 );


### PR DESCRIPTION
## 📝 작업 내용

1. 로그인 했을 때만 접근 가능한 페이지 / 로그인 상태가 아닐때만 접근 가능한 페이지로 나눔
2. 로그인 후에 헤더와 SNB가 공통이니까 페이지 마다 불러올 필요 없이 무조건 동일한 레이아웃을 유지하도록 수정
3. 레이아웃을 위한 자잘한 css 수정이 있었습니다
4. 
## #️⃣연관된 이슈 (선택)
#37 
