### PR TITLE
CHORE: alert을 toast로 대체 외 2건

### DIFF
--- a/src/components/modal-contents/create-card/index.tsx
+++ b/src/components/modal-contents/create-card/index.tsx
@@ -66,7 +66,7 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
         imageUrl ? imageUrl : undefined,
       );
 
-      alert('생성 성공');
+      toast.success('생성 성공');
       dispatch(closeModal());
     } catch (err) {
       alert(`오류가 발생했습니다.(${err})`);
@@ -109,7 +109,7 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
     if (e.target.files && e.target.files.length > 0) {
       const file = e.target.files[0];
       if (!file.type.startsWith('image/') || file.type === 'image/gif') {
-        alert('파일은 gif를 제외한 이미지 타입만 첨부 가능합니다.');
+        toast.warning('파일은 gif를 제외한 이미지 타입만 첨부 가능합니다.');
       } else {
         setUploadedFile(file);
         const formData = new FormData();

--- a/src/components/modal-contents/create-card/index.tsx
+++ b/src/components/modal-contents/create-card/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, ChangeEvent, KeyboardEvent } from 'react';
+import { useState, useEffect, useRef, ChangeEvent, KeyboardEvent, MouseEvent } from 'react';
 import { useDispatch } from 'react-redux';
 import { closeModal } from '@/redux/modalSlice';
 import { dashboardIdTypes } from '@/types/dashboardIdTypes';
@@ -104,6 +104,12 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
       setTags((prev) => [...prev, input]);
       setCardData({ ...cardData, tag: '' });
     }
+  };
+
+  const handleRemoveTag = (e: MouseEvent<HTMLElement>) => {
+    const target = e.target as HTMLElement;
+    const removeTag = target.innerText;
+    setTags(tags.filter((item) => item !== removeTag));
   };
 
   const handleUploadFile = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -261,7 +267,12 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
           <div className='input-box tag-list'>
             {tags &&
               tags.map((tag, index) => (
-                <TagComponent key={index} name={tag} backgroundColor={makeRandomBackgroundColor(index)} />
+                <TagComponent
+                  key={index}
+                  name={tag}
+                  backgroundColor={makeRandomBackgroundColor(index)}
+                  onClick={(e) => handleRemoveTag(e)}
+                />
               ))}
           </div>
         </div>

--- a/src/components/modal-contents/create-card/index.tsx
+++ b/src/components/modal-contents/create-card/index.tsx
@@ -26,6 +26,7 @@ interface Props {
 const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) => {
   const dispatch = useDispatch();
   const today = new Date();
+  const imgRef = useRef<HTMLImageElement>(null!);
   const assigneeRef = useRef<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -126,6 +127,26 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
     }
   };
 
+  const handleAssigneeClear = () => {
+    const img = imgRef.current;
+    if (img) img.classList.add('hidden');
+    assigneeRef.current = null;
+    setCardData({ ...cardData, asignee: '' });
+    setUserProfile('');
+  };
+
+  useEffect(() => {
+    viewCards();
+    if (memberData.length > 0) {
+      // 멤버 목록을 받아왔을때 프로필이 null이면 기본값으로 변경
+      memberData.forEach((member) => {
+        member.profileImageUrl = member.profileImageUrl
+          ? member.profileImageUrl
+          : '/assets/image/icons/bannerLogoIconXL.svg';
+      });
+    }
+  }, [memberData]);
+
   useEffect(() => {
     // 입력값이 변할때마다 검색결과 재적용
     if (cardData.asignee !== '') {
@@ -152,8 +173,15 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
       <StCreateCard $Profile={userProfile} $IsDropdown={isDropdown} $Tag={tags} $Preview={previewUrl}>
         {isLoading && <LoadingSpinner />}
         <div className='section-div first-div'>
-          <h3>담당자</h3>
+          <h3 onClick={handleAssigneeClear}>담당자</h3>
+          <img
+            src='/assets/image/icons/removeIcon.svg'
+            className='remove-icon'
+            alt='remove-icon'
+            onClick={handleAssigneeClear}
+          />
           <input
+            value={cardData.asignee}
             className='input-box asignee-box'
             placeholder='이름을 입력해 주세요'
             type='text'
@@ -162,7 +190,7 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
             onFocus={(e) => handleDropdown(e)}
             onBlur={() => setIsDropdown(false)}
           />
-          {userProfile && <img src={userProfile} className='user-image in-searchbar' />}
+          {userProfile && <img src={userProfile} className='user-image in-searchbar' ref={imgRef} />}
           <div className='input-box member-list'>
             {isDropdown &&
               filterdMember.map((member) => (

--- a/src/components/modal-contents/create-card/style.ts
+++ b/src/components/modal-contents/create-card/style.ts
@@ -21,6 +21,15 @@ const StCreateCard = styled.div<{
       }
     }
 
+    .remove-icon {
+      position: absolute;
+      width: 18px;
+      height: 18px;
+      left: 50px;
+      top: 2px;
+      cursor: pointer;
+    }
+
     .input-box {
       width: 100%;
       padding: 15px 0px 15px 16px;

--- a/src/components/modal-contents/edit-card/index.tsx
+++ b/src/components/modal-contents/edit-card/index.tsx
@@ -69,7 +69,7 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
         imageUrl: imageUrl ? imageUrl : undefined,
       });
 
-      alert('수정완료');
+      toast.success('수정완료');
       dispatch(closeModal());
     } catch (err) {
       alert(err);
@@ -134,7 +134,7 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
     if (e.target.files && e.target.files.length > 0) {
       const file = e.target.files[0];
       if (!file.type.startsWith('image/') || file.type === 'image/gif') {
-        alert('파일은 gif를 제외한 이미지 타입만 첨부 가능합니다.');
+        toast.warning('파일은 gif를 제외한 이미지 타입만 첨부 가능합니다.');
       } else {
         setUploadedFile(file);
         const formData = new FormData();

--- a/src/pages/dashboard-id/index.tsx
+++ b/src/pages/dashboard-id/index.tsx
@@ -1,25 +1,25 @@
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { ModalRootState } from '@/redux/modalSlice';
+import { dashboardIdTypes } from '@/types/dashboardIdTypes';
 import axiosInstance from '@/api/instance/axiosInstance';
 import Container from './style';
 import AddColumnButton from '@/components/add-column-button';
 import API from '@/api/constants';
-import { useEffect, useState } from 'react';
 import Column from '@/components/column';
 import LoadingSpinner from '@/components/loading-spinner';
 import AddColumnModal from '../../components/modal-add-column';
-import { useSelector } from 'react-redux';
-import { ModalRootState } from '@/redux/modalSlice';
-import { dashboardIdTypes } from '@/types/dashboardIdTypes';
 
 const DashBoardId = () => {
   const { id } = useParams();
-  const [columns, setColumns] = useState<dashboardIdTypes['Columns'][]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
   const openModalName = useSelector((state: ModalRootState) => state.modal.openModalName);
+  const [columns, setColumns] = useState<dashboardIdTypes['Columns'][]>([]);
   const [members, setMembers] = useState<dashboardIdTypes['Members'][]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   const viewColumns = () => {
-    // 컬럼 조회 함수
     setIsLoading(true);
     axiosInstance
       .get(`${API.COLUMNS.COLUMNS}?dashboardId=${id}`)
@@ -27,15 +27,20 @@ const DashBoardId = () => {
         setColumns(res.data.data);
         setIsLoading(false);
       })
-      .catch(() => alert('컬럼 조회 실패'));
+      .catch(() => {
+        alert('컬럼 조회 실패');
+        navigate('/');
+      });
   };
 
   const viewMembers = () => {
-    // 초대받은 멤버 조회 함수
     axiosInstance
       .get(`${API.MEMBERS.MEMBERS}?page=1&size=9999&dashboardId=${id}`)
       .then((res) => setMembers(res.data.members))
-      .catch(() => alert('멤버 조회 실패'));
+      .catch(() => {
+        alert('멤버 조회 실패');
+        navigate('/');
+      });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 📝 작업 내용

- alert 토스트로 바꿨습니다
- 에러발생한다면 루트페이지로 리다이렉트 합니다
- 카드생성에서도 담당자 input 비우는 버튼을 추가했습니다

### 스크린샷 (선택)
![image](https://github.com/HappyDevelopers-team7/team7-taskify/assets/151588293/4c6d1f74-5c42-4d4d-9b58-e2a66ed2c22f)
![image](https://github.com/HappyDevelopers-team7/team7-taskify/assets/151588293/d330f3d8-962a-4bb2-b478-fd1183ec7984)
![image](https://github.com/HappyDevelopers-team7/team7-taskify/assets/151588293/fe0e5be0-c537-45f3-902d-3ff75c1331d8)

## 💬리뷰 요구사항(선택)

- 태그도 추가/삭제할때 애니메이션을 넣어보려고 했는데 잘 안되네요;;

## #️⃣연관된 이슈 (선택)
