### PR TITLE
REFACTOR: 카드를 다른 컬럼으로 옮겼을때 새로고침없이 화면 리렌더링

### DIFF
--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -38,7 +38,6 @@ const Card = ({ cardList, setCardList, card, idGroup, thisColumn, columns, membe
         dispatch(closeSecondModal());
         dispatch(closeModal());
         const updatedCommentList = cardList?.filter((cardItem) => cardItem.id !== card.id);
-        // setCardList(updatedCommentList);
         setCardList((prev) => ({
           ...prev,
           [thisColumn.id]: updatedCommentList,
@@ -48,6 +47,8 @@ const Card = ({ cardList, setCardList, card, idGroup, thisColumn, columns, membe
       return toast.success(SIMPLE_MESSAGES.TRY_AGAIN);
     } catch (error) {
       alert(error);
+    } finally {
+      viewCards(thisColumn.id);
     }
   };
 

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -17,13 +17,13 @@ import { dashboardIdTypes } from '@/types/dashboardIdTypes';
 
 interface CardProps {
   cardList: ColumnCardType[];
-  setCardList: Dispatch<SetStateAction<ColumnCardType[] | undefined>>;
+  setCardList: Dispatch<SetStateAction<Record<string, ColumnCardType[]> | undefined>>;
   idGroup: IdGroupType;
   card: ColumnCardType;
   columns: dashboardIdTypes['Columns'][];
   thisColumn: dashboardIdTypes['Columns'];
   memberData: dashboardIdTypes['Members'][];
-  viewCards: () => void;
+  viewCards: (columId: number) => void;
 }
 
 const Card = ({ cardList, setCardList, card, idGroup, thisColumn, columns, memberData, viewCards }: CardProps) => {
@@ -38,7 +38,11 @@ const Card = ({ cardList, setCardList, card, idGroup, thisColumn, columns, membe
         dispatch(closeSecondModal());
         dispatch(closeModal());
         const updatedCommentList = cardList?.filter((cardItem) => cardItem.id !== card.id);
-        setCardList(updatedCommentList);
+        // setCardList(updatedCommentList);
+        setCardList((prev) => ({
+          ...prev,
+          [thisColumn.id]: updatedCommentList,
+        }));
         return toast.success(SIMPLE_MESSAGES.DELETED);
       }
       return toast.success(SIMPLE_MESSAGES.TRY_AGAIN);

--- a/src/components/column/index.tsx
+++ b/src/components/column/index.tsx
@@ -5,24 +5,12 @@ import { useEffect, useState, Dispatch, SetStateAction } from 'react';
 import { ModalRootState, openModal, setOpenModalName } from '@/redux/modalSlice';
 import { ColumnCardType } from '@/types/columnCardType';
 import { dashboardIdTypes } from '@/types/dashboardIdTypes';
-import { Types } from '@/types/columnDetailTypes';
 import axiosInstance from '@/api/instance/axiosInstance';
 import API from '@/api/constants';
 import Card from '../card';
 import LoadingSpinner from '@/components/loading-spinner';
 import EditColumnModal from '../modal-edit-column';
 import CreateCard from '../modal-contents/create-card';
-
-// Column - CardInfo[]
-// Column - CardInfo[]
-// Column - CardInfo[]
-
-// {
-//   columId: CardInfo[],
-//   columId: CardInfo[]
-//   columId: CardInfo[]
-//   columId: CardInfo[]
-// }
 
 interface Props {
   columnData: dashboardIdTypes['Columns'];
@@ -33,13 +21,25 @@ interface Props {
   cardInfo: Record<string, ColumnCardType[]> | undefined;
   // setState type
   setCardInfo: Dispatch<SetStateAction<Record<string, ColumnCardType[]> | undefined>>;
+  totalCount: Record<number, number> | undefined;
+  setTotalCount: Dispatch<SetStateAction<Record<number, number> | undefined>>;
 }
 
-const Column = ({ columnData, memberData, viewColumns, dashboardId, columns, setCardInfo, cardInfo }: Props) => {
+const Column = ({
+  columnData,
+  memberData,
+  viewColumns,
+  dashboardId,
+  columns,
+  setCardInfo,
+  cardInfo,
+  totalCount,
+  setTotalCount,
+}: Props) => {
   const dispatch = useDispatch<AppDispatch>();
   const MORE_CARDS = 3;
   const openModalName = useSelector((state: ModalRootState) => state.modal.openModalName);
-  const [totalCount, setTotalCount] = useState<Types['totalCount']>(0);
+  //const [totalCount, setTotalCount] = useState<Types['totalCount']>(0);
   const [isLoading, setIsLoading] = useState(false);
   const [pages, setPages] = useState<number>(MORE_CARDS);
 
@@ -76,7 +76,11 @@ const Column = ({ columnData, memberData, viewColumns, dashboardId, columns, set
           ...prev,
           [columId]: res.data.cards,
         }));
-        setTotalCount(res.data.totalCount);
+        setTotalCount((prev) => ({
+          ...prev,
+          [columId]: res.data.totalCount,
+        }));
+        console.log(totalCount);
       })
       .catch((err) => alert(`카드 조회 실패(${err})`))
       .finally(() => setIsLoading(false));
@@ -84,7 +88,7 @@ const Column = ({ columnData, memberData, viewColumns, dashboardId, columns, set
 
   useEffect(() => {
     viewCards(columnData.id);
-  }, [pages, totalCount]);
+  }, [pages]);
 
   const cardList = (cardInfo && cardInfo[columnData.id]) || [];
   return (
@@ -93,7 +97,7 @@ const Column = ({ columnData, memberData, viewColumns, dashboardId, columns, set
       <div className='column-head'>
         <div className='column-color' />
         <h2>{columnData.title}</h2>
-        <div className='inner-cards'>{totalCount}</div>
+        <div className='inner-cards'>{totalCount && totalCount[columnData.id]}</div>
         <img src='/assets/image/icons/settingIcon.svg' alt='setting-icon' onClick={handleEditColumn} />
       </div>
 
@@ -117,7 +121,7 @@ const Column = ({ columnData, memberData, viewColumns, dashboardId, columns, set
       </div>
 
       <div className='column-foot'>
-        {totalCount > pages && (
+        {totalCount && totalCount[columnData.id] > pages && (
           <button
             onClick={() => {
               setPages((prev) => prev + MORE_CARDS);

--- a/src/components/modal-contents/create-card/index.tsx
+++ b/src/components/modal-contents/create-card/index.tsx
@@ -20,7 +20,7 @@ interface Props {
   columnData: dashboardIdTypes['Columns'];
   memberData: dashboardIdTypes['Members'][];
   dashboardId: string | undefined;
-  viewCards: () => void;
+  viewCards: (columId: number) => void;
 }
 
 const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) => {
@@ -73,7 +73,7 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
       alert(`오류가 발생했습니다.(${err})`);
     } finally {
       setIsLoading(false);
-      viewCards();
+      viewCards(columnData.id);
     }
   };
 
@@ -142,7 +142,7 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
   };
 
   useEffect(() => {
-    viewCards();
+    viewCards(columnData.id);
     if (memberData.length > 0) {
       // 멤버 목록을 받아왔을때 프로필이 null이면 기본값으로 변경
       memberData.forEach((member) => {
@@ -164,7 +164,6 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
     } else if (cardData.asignee === '') {
       SetFilterdMember(memberData);
     }
-    console.log(filterdMember);
   }, [cardData]);
 
   return (

--- a/src/components/modal-contents/create-card/index.tsx
+++ b/src/components/modal-contents/create-card/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, ChangeEvent, KeyboardEvent, MouseEvent } from 'react';
+import { useState, useEffect, useRef, ChangeEvent, KeyboardEvent } from 'react';
 import { useDispatch } from 'react-redux';
 import { closeModal } from '@/redux/modalSlice';
 import { dashboardIdTypes } from '@/types/dashboardIdTypes';
@@ -106,10 +106,8 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
     }
   };
 
-  const handleRemoveTag = (e: MouseEvent<HTMLElement>) => {
-    const target = e.target as HTMLElement;
-    const removeTag = target.innerText;
-    setTags(tags.filter((item) => item !== removeTag));
+  const handleRemoveTag = (tag: string) => {
+    setTags(tags.filter((item) => item !== tag));
   };
 
   const handleUploadFile = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -270,7 +268,7 @@ const CreateCard = ({ memberData, columnData, dashboardId, viewCards }: Props) =
                   key={index}
                   name={tag}
                   backgroundColor={makeRandomBackgroundColor(index)}
-                  onClick={(e) => handleRemoveTag(e)}
+                  onClick={() => handleRemoveTag(tag)}
                 />
               ))}
           </div>

--- a/src/components/modal-contents/edit-card/index.tsx
+++ b/src/components/modal-contents/edit-card/index.tsx
@@ -75,9 +75,8 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
       alert(err);
     } finally {
       setIsLoading(false);
-      viewCards(selectedColumnId);
       viewCards(thisColumn.id);
-      //window.location.reload();
+      viewCards(selectedColumnId);
     }
   };
 

--- a/src/components/modal-contents/edit-card/index.tsx
+++ b/src/components/modal-contents/edit-card/index.tsx
@@ -64,7 +64,7 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
         assigneeUserId: asigneeRef ? asigneeRef.current : undefined,
         title: editCardData.title,
         description: editCardData.description,
-        dueDate: editCardData.dueDate ? editCardData.dueDate : undefined,
+        dueDate: editCardData.dueDate ? editCardData.dueDate : null,
         tags: tags,
         imageUrl: imageUrl ? imageUrl : undefined,
       });
@@ -290,7 +290,7 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
               minDate: dateExtractor(today).slice(0, 10),
               closeOnSelect: true,
             }}
-            onChange={(e) => setEditCardData({ ...editCardData, dueDate: dateExtractor(e[0]) })}
+            onChange={(e) => setEditCardData({ ...editCardData, dueDate: e[0] ? dateExtractor(e[0]) : null })}
           />
         </div>
         <div>

--- a/src/components/modal-contents/edit-card/index.tsx
+++ b/src/components/modal-contents/edit-card/index.tsx
@@ -123,10 +123,8 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
     }
   };
 
-  const handleRemoveTag = (e: MouseEvent<HTMLElement>) => {
-    const target = e.target as HTMLElement;
-    const removeTag = target.innerText;
-    setTags(tags.filter((item) => item !== removeTag));
+  const handleRemoveTag = (tag: string) => {
+    setTags(tags.filter((item) => item !== tag));
   };
 
   const handleUploadFile = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -310,7 +308,7 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
                   key={index}
                   name={tag}
                   backgroundColor={makeRandomBackgroundColor(index)}
-                  onClick={(e) => handleRemoveTag(e)}
+                  onClick={() => handleRemoveTag(tag)}
                 />
               ))}
           </div>

--- a/src/components/modal-contents/edit-card/index.tsx
+++ b/src/components/modal-contents/edit-card/index.tsx
@@ -160,6 +160,18 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
   };
 
   useEffect(() => {
+    viewCards();
+    if (memberData.length > 0) {
+      // 멤버 목록을 받아왔을때 프로필이 null이면 기본값으로 변경
+      memberData.forEach((member) => {
+        member.profileImageUrl = member.profileImageUrl
+          ? member.profileImageUrl
+          : '/assets/image/icons/bannerLogoIconXL.svg';
+      });
+    }
+  }, [memberData]);
+
+  useEffect(() => {
     if (asgineeName !== '') {
       const data = [...memberData];
       const filterdData = data.filter((member) => {

--- a/src/components/modal-contents/edit-card/index.tsx
+++ b/src/components/modal-contents/edit-card/index.tsx
@@ -75,8 +75,9 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
       alert(err);
     } finally {
       setIsLoading(false);
-      viewCards();
-      window.location.reload();
+      viewCards(selectedColumnId);
+      viewCards(thisColumn.id);
+      //window.location.reload();
     }
   };
 
@@ -160,7 +161,7 @@ const EditCard = ({ card, thisColumn, columns, memberData, viewCards }: CardObje
   };
 
   useEffect(() => {
-    viewCards();
+    viewCards(thisColumn.id);
     if (memberData.length > 0) {
       // 멤버 목록을 받아왔을때 프로필이 null이면 기본값으로 변경
       memberData.forEach((member) => {

--- a/src/pages/dashboard-id/index.tsx
+++ b/src/pages/dashboard-id/index.tsx
@@ -11,6 +11,8 @@ import Column from '@/components/column';
 import LoadingSpinner from '@/components/loading-spinner';
 import AddColumnModal from '../../components/modal-add-column';
 
+import { ColumnCardType } from '@/types/columnCardType';
+
 const DashBoardId = () => {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -18,6 +20,7 @@ const DashBoardId = () => {
   const [columns, setColumns] = useState<dashboardIdTypes['Columns'][]>([]);
   const [members, setMembers] = useState<dashboardIdTypes['Members'][]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [cardInfo, setCardInfo] = useState<Record<string, ColumnCardType[]>>();
 
   const viewColumns = () => {
     setIsLoading(true);
@@ -60,6 +63,8 @@ const DashBoardId = () => {
             memberData={members}
             viewColumns={viewColumns}
             columns={columns}
+            cardInfo={cardInfo}
+            setCardInfo={setCardInfo}
           />
         ))}
       <div className='button-box'>

--- a/src/pages/dashboard-id/index.tsx
+++ b/src/pages/dashboard-id/index.tsx
@@ -21,6 +21,7 @@ const DashBoardId = () => {
   const [members, setMembers] = useState<dashboardIdTypes['Members'][]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [cardInfo, setCardInfo] = useState<Record<string, ColumnCardType[]>>();
+  const [totalCount, setTotalCount] = useState<Record<number, number>>();
 
   const viewColumns = () => {
     setIsLoading(true);
@@ -65,6 +66,8 @@ const DashBoardId = () => {
             columns={columns}
             cardInfo={cardInfo}
             setCardInfo={setCardInfo}
+            totalCount={totalCount}
+            setTotalCount={setTotalCount}
           />
         ))}
       <div className='button-box'>

--- a/src/types/cardObjectType.ts
+++ b/src/types/cardObjectType.ts
@@ -18,5 +18,5 @@ export type CardObjectType = {
   columns: dashboardIdTypes['Columns'][];
   thisColumn: dashboardIdTypes['Columns'];
   memberData: dashboardIdTypes['Members'][];
-  viewCards: () => void;
+  viewCards: (columnId: number) => void;
 };


### PR DESCRIPTION
## 📝 작업 내용

- 할일수정 컬럼 이동될시 창 새로고침 없이 렌더링
- 할일수정에서 마감일 input창 지우고 제출하면 마감일 미지정 상태 되도록 수정
- 기타 소소한 리팩토링

### 스크린샷 (선택)
![Taskify_team7-Chrome2024-03-2218-45-45-ezgif com-video-to-gif-converter](https://github.com/HappyDevelopers-team7/team7-taskify/assets/151588293/8af5fb30-6d2c-4b66-ba58-37170bc80af4)

## 💬리뷰 요구사항(선택)

- 새로고침 없이 렌더링 구현하는 과정에서 자료구조가 변해서 유정님이 만드신 handleDeleteCard의 로직이 좀 바뀌었습니다. 혹시 변경사항 보시고 이해 안되시면 DM주세용

## #️⃣연관된 이슈 (선택)
> ex) #이슈번호, #이슈번호
