### PR TITLE
대시보드 멤버 삭제 & 이메일 추가 컴포넌트  수정

### DIFF
--- a/src/api/postInviteDashboard.ts
+++ b/src/api/postInviteDashboard.ts
@@ -1,16 +1,22 @@
 import { AxiosError } from 'axios';
 import API from './constants';
 import axiosInstance from './instance/axiosInstance';
+import { toast } from 'react-toastify';
 
 export const postInviteDashboard = async (email: string, dashboardId: string) => {
   try {
     const res = await axiosInstance.post(`${API.DASHBOARDS.DASHBOARDS}/${dashboardId}/invitations`, {
       email,
     });
+    console.log(res);
     const resData = await res;
     return resData;
   } catch (e) {
     const error = e as AxiosError;
+    if (error.response && error.response.status === 404) {
+      toast.error('존재하지 않는 email 입니다.');
+      return;
+    }
     return error.response;
   }
 };

--- a/src/components/edit-dashboard-invite-list/index.tsx
+++ b/src/components/edit-dashboard-invite-list/index.tsx
@@ -95,10 +95,10 @@ const EditDashBoardInviteList = () => {
 
   const currentInvites = list?.invitations || [];
 
-  const uniqueInvites = currentInvites.filter(
-    //중복된 이메일 제거함
-    (invite, index, self) => self.findIndex((t) => t.invitee.email === invite.invitee.email) === index,
-  );
+  // const uniqueInvites = currentInvites.filter(
+  //   //중복된 이메일 제거함
+  //   (invite, index, self) => self.findIndex((t) => t.invitee.email === invite.invitee.email) === index,
+  // );
 
   const getContainerSizeClass = (length: number) => {
     if (length >= 5) {
@@ -108,7 +108,7 @@ const EditDashBoardInviteList = () => {
     }
   };
 
-  const containerSize = getContainerSizeClass(uniqueInvites.length);
+  const containerSize = getContainerSizeClass(currentInvites.length);
 
   return (
     <StInviteList>
@@ -121,8 +121,8 @@ const EditDashBoardInviteList = () => {
           <ArrowButton
             onLeftClick={handleLeftClick}
             onRightClick={handleRightClick}
-            leftDisabled={currentPage === 1 || uniqueInvites.length === 0}
-            rightDisabled={currentPage === totalPages || uniqueInvites.length === 0}
+            leftDisabled={currentPage === 1 || currentInvites.length === 0}
+            rightDisabled={currentPage === totalPages || currentInvites.length === 0}
           />
           <button className='invite-button' onClick={handleClickInviteDashboard}>
             <img src='/assets/image/icons/addBoxIcon.svg' alt='초대하기(플러스) 아이콘' />
@@ -132,7 +132,7 @@ const EditDashBoardInviteList = () => {
       </div>
       <p className='email'>이메일</p>
       <ul className={`member-list ${containerSize}`}>
-        {uniqueInvites.map((list, index) => (
+        {currentInvites.map((list, index) => (
           <React.Fragment key={list.id}>
             <li key={list.id}>
               {list.invitee.email}
@@ -140,7 +140,7 @@ const EditDashBoardInviteList = () => {
                 취소
               </button>
             </li>
-            {index !== uniqueInvites.length - 1 && (
+            {index !== currentInvites.length - 1 && (
               <div className='gray-line' key={`line-${list.invitee.id}-${index}`} />
             )}
           </React.Fragment>

--- a/src/components/edit-dashboard-member-list/index.tsx
+++ b/src/components/edit-dashboard-member-list/index.tsx
@@ -50,15 +50,19 @@ const EditDashboardMemberList = () => {
   }, [id, currentPage]);
 
   const handleDeleteUserClick = (memberId: number) => {
-    deleteDashboardMember(memberId)
-      .then(() => {
-        toast.success('삭제가 완료 되었습니다.');
-        if (!id) return;
-        fetchDashboardMemberList(id, currentPage, setMember, setTotalPages, MEMBERS_PER_PAGE);
-      })
-      .catch((error) => {
-        console.error('fetching delete member error:', error);
-      });
+    if (myInfo.id === memberId) {
+      handleDeleteFailMySelf();
+    } else {
+      deleteDashboardMember(memberId)
+        .then(() => {
+          toast.success('삭제가 완료 되었습니다.');
+          if (!id) return;
+          fetchDashboardMemberList(id, currentPage, setMember, setTotalPages, MEMBERS_PER_PAGE);
+        })
+        .catch((error) => {
+          console.error('fetching delete member error:', error);
+        });
+    }
   };
 
   const handleDeleteFailMySelf = () => {
@@ -132,15 +136,10 @@ const EditDashboardMemberList = () => {
                 //   <p>{member.nickname}</p>
                 // </div>
               )}
-              {myInfo.id === member.id ? (
-                <button className='delete-button' onClick={() => handleDeleteUserClick(member.id)}>
-                  삭제
-                </button>
-              ) : (
-                <button className='delete-button' onClick={handleDeleteFailMySelf}>
-                  삭제
-                </button>
-              )}
+
+              <button className='delete-button' onClick={() => handleDeleteUserClick(member.id)}>
+                삭제
+              </button>
             </li>
             {index !== currentMembers.length - 1 && <div className='gray-line' key={`line-${member.id}-${index}`} />}
           </React.Fragment>


### PR DESCRIPTION
## 📝 작업 내용

대시보드 멤버 삭제에서 삭제가 안되는거기능 수정
(자기 자신 삭제 막는것은 이후 리펙토링에서 해야할거같음)

대시보드 초대 리스트 에서 
이미 초대된 이메일이면 토스트를 띄우게 함

## #️⃣연관된 이슈 (선택)
> #100
